### PR TITLE
Fix: Prevent structure removal when alias is a prefix of another structure

### DIFF
--- a/C4InterFlow/Visualisation/DiagramBuildRunner.cs
+++ b/C4InterFlow/Visualisation/DiagramBuildRunner.cs
@@ -96,13 +96,12 @@ public abstract class DiagramBuildRunner : IDiagramBuildRunner
 
         foreach (var structure in structures.ToArray())
         {
-            if (structures.Any(x => !x.Alias.Equals(structure.Alias) && structure.Alias.StartsWith(x.Alias)))
+            if (structures.Any(x => !x.Alias.Equals(structure.Alias) && structure.Alias.StartsWith(x.Alias + ".")))
             {
                 structures.Remove(structure);
             }
         }
 
-        
         var boundaries = structures.OfType<IBoundary>().ToArray();
         var otherStructures = structures.Where(s => s is not IBoundary).ToArray();
 


### PR DESCRIPTION
Fixes #162 

Software systems were incorrectly filtered from Context diagrams when their alias was a prefix of another system's alias. Changed the CleanUpStructures method to check for dot separator after the prefix to distinguish between sibling systems and true parent-child relationships.
